### PR TITLE
Use correct email variable

### DIFF
--- a/app/code/community/Sendinblue/Sendinblue/Model/Observer.php
+++ b/app/code/community/Sendinblue/Sendinblue/Model/Observer.php
@@ -267,7 +267,7 @@ class Sendinblue_Sendinblue_Model_Observer
         $abandonedCartStatus = Mage::getStoreConfig('sendinblue/tracking/abandonedcartstatus');
         $email = Mage::helper('sendinblue')->getEmail();
        
-        if (empty(email)) {
+        if (empty($email)) {
             $email = $orderData['customer_email'];
         }
         if (empty($automationKey) || $abandonedCartStatus != 1 || empty($email)) { 


### PR DESCRIPTION
Fixes the following error:

Warning: Use of undefined constant email - assumed 'email' (this will throw an Error in a future version of PHP) in /var/www/html/app/code/community/Sendinblue/Sendinblue/Model/Observer.php on line 270